### PR TITLE
Add empty world with unlimited simulation speed

### DIFF
--- a/mara_gazebo/worlds/empty_headless.world
+++ b/mara_gazebo/worlds/empty_headless.world
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <!-- Speed up the simulation to the maximum -->
+    <physics type='ode'>
+      <real_time_update_rate>0</real_time_update_rate>
+    </physics>
+  </world>
+</sdf>


### PR DESCRIPTION
This world will be used as the base launch option when performing reinforcement learning operations with ros2. The only objective of the world is to change physics properties.

`real_time_update_rate` is set to 0, a.k.a _unlimited_ or *headless*.