### PR TITLE
Remove unused hrim_sensor_camera_msgs +  Update HRIM instructions for python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ sudo apt install python3-numpy
 Generate HRIM dependencies:
 
 ```bash
-sudo apt-get install python-lxml
+pip3 install lxml
 cd ~/ros2_mara_ws/src/HRIM
-python hrim.py generate models/actuator/servo/servo.xml
-python hrim.py generate models/actuator/gripper/gripper.xml
+python3 hrim.py generate models/actuator/servo/servo.xml
+python3 hrim.py generate models/actuator/gripper/gripper.xml
 ```
 
 ## Compile

--- a/mara_utils_scripts/scripts/mara_joint_control.py
+++ b/mara_utils_scripts/scripts/mara_joint_control.py
@@ -17,7 +17,6 @@ from rclpy.qos import qos_profile_default, qos_profile_sensor_data
 
 import rclpy
 
-import cv2
 import numpy as np
 import os
 beloop= False

--- a/mara_utils_scripts/scripts/mara_joint_control.py
+++ b/mara_utils_scripts/scripts/mara_joint_control.py
@@ -13,7 +13,6 @@ import time
 
 #ROS 2.0
 from hrim_actuator_rotaryservo_msgs.msg import GoalRotaryServo
-from hrim_sensor_camera_msgs.msg import CompressedImage
 from rclpy.qos import qos_profile_default, qos_profile_sensor_data
 
 import rclpy


### PR DESCRIPTION
camera msgs are not used + not generated by HRIM since we don't need them. Just remove.