### PR TITLE
Fix adding model path to environment variables

### DIFF
--- a/robotiq_gazebo/launch/robotiq_85.launch.py
+++ b/robotiq_gazebo/launch/robotiq_85.launch.py
@@ -15,7 +15,7 @@ def generate_launch_description():
     print("install_dir ", install_dir)
 
     if 'GAZEBO_MODEL_PATH' in os.environ:
-        os.environ['GAZEBO_MODEL_PATH'] =  os.environ['GAZEBO_MODEL_PATH'] + ':' + install_dir + 'share'
+        os.environ['GAZEBO_MODEL_PATH'] =  os.environ['GAZEBO_MODEL_PATH'] + ':' + install_dir + '/share'
     else:
         os.environ['GAZEBO_MODEL_PATH'] =  install_dir + "/share"
 

--- a/robotiq_gazebo/launch/robotiq_hande.launch.py
+++ b/robotiq_gazebo/launch/robotiq_hande.launch.py
@@ -13,7 +13,7 @@ def generate_launch_description():
     install_dir = get_package_prefix('robotiq_hande_gripper_description')
 
     if 'GAZEBO_MODEL_PATH' in os.environ:
-        os.environ['GAZEBO_MODEL_PATH'] =  os.environ['GAZEBO_MODEL_PATH'] + ':' + install_dir + 'share'
+        os.environ['GAZEBO_MODEL_PATH'] =  os.environ['GAZEBO_MODEL_PATH'] + ':' + install_dir + '/share'
     else:
         os.environ['GAZEBO_MODEL_PATH'] =  install_dir + "/share"
 


### PR DESCRIPTION
Fix the GAZEBO_MODEL_PATH environmental variable pathing for robotiq_85.launch.py and robotiq_hande.launch.py