### PR TITLE
Fix robotiq 85 gripper urdf joint name mispelling

### DIFF
--- a/robotiq_85_gripper_description/urdf/robotiq_85.urdf
+++ b/robotiq_85_gripper_description/urdf/robotiq_85.urdf
@@ -276,7 +276,7 @@
     <axis xyz="0 1 0"/>
     <limit effort="1000" lower="0.0" upper="0.8757" velocity="2.0"/>
   </joint>
-  <joint name="right_inner_knuckler_joint" type="revolute">
+  <joint name="right_inner_knuckle_joint" type="revolute">
     <origin rpy="0 0 3.1416" xyz="0.0306 0 0.05490"/>
     <parent link="robotiq_85_base_link"/>
     <child link="robotiq_85_right_inner_knuckle_link"/>

--- a/robotiq_85_gripper_description/urdf/robotiq_85.urdf.xacro
+++ b/robotiq_85_gripper_description/urdf/robotiq_85.urdf.xacro
@@ -286,7 +286,7 @@
       <limit lower="0.0" upper="0.8757" velocity="2.0" effort="1000" />
     </joint>
 
-    <joint name="right_inner_knuckler_joint" type="revolute">
+    <joint name="right_inner_knuckle_joint" type="revolute">
       <origin xyz="0.0306 0 0.05490" rpy="0 0 3.1416" />
       <parent link="robotiq_85_base_link" />
       <child link="robotiq_85_right_inner_knuckle_link" />


### PR DESCRIPTION
Fix robotiq 85 gripper urdf joint name mispelling from right_inner_knuckler_joint to right_inner_knuckle_joint at robotiq_85.urdf and robotiq_85.urdf.xacro