### PR TITLE
Remove contact tag from autogenerated urdf

### DIFF
--- a/mara_description/urdf/mara_robot_camera_top.urdf
+++ b/mara_description/urdf/mara_robot_camera_top.urdf
@@ -794,9 +794,6 @@
     <plugin filename="librobotiq_gripper_gazebo_plugin.so" name="hros_actuation_gripper_000000000004"/>
   </gazebo>
   <link name="table">
-    <contact>
-      <lateral_friction value="1.0"/>
-    </contact>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <mass value="0.00001"/>


### PR DESCRIPTION
Possibly causing errors. At least we can remove warnings this way.