### PR TITLE
Create mara_contact_publisher

### DIFF
--- a/mara_contact_publisher/CMakeLists.txt
+++ b/mara_contact_publisher/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.5)
+project(mara_contact_publisher)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -fpermissive")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(gazebo_dev REQUIRED)
+find_package(gazebo_ros REQUIRED)
+find_package(gazebo_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+
+include_directories(include
+  ${gazebo_dev_INCLUDE_DIRS}
+  ${gazebo_ros_INCLUDE_DIRS}
+  ${gazebo_msgs_INCLUDE_DIRS}
+  ${geometry_msgs_INCLUDE_DIRS}
+)
+link_directories(${gazebo_dev_LIBRARY_DIRS})
+
+# Declare a C++ executable
+set(${PROJECT_NAME}_SOURCES
+  src/ContactPublisher.cpp
+)
+
+add_executable(${PROJECT_NAME}
+  ${${PROJECT_NAME}_SOURCES}
+)
+
+ament_target_dependencies(${PROJECT_NAME}
+  "rclcpp"
+  "gazebo_dev"
+  "gazebo_ros"
+  "gazebo_msgs"
+  "geometry_msgs"
+)
+
+install(TARGETS
+  ${PROJECT_NAME}
+DESTINATION
+  lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/mara_contact_publisher/package.xml
+++ b/mara_contact_publisher/package.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>mara_contact_publisher</name>
+  <version>0.0.2</version>
+  <description>
+        Gazebo contact ROS2 publisher.
+  </description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <maintainer email="alex@erlerobotics.com">Alejandro Hernández Cordero</maintainer>
+  <license>GPLv3</license>
+
+  <author email="alex@erlerobotics.com">Alejandro Hernández Cordero</author>
+  <author email="nestor@erlerobotics.com">Nestor Gonzalez</author>
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>gazebo_ros</build_depend>
+  <build_depend>gazebo_dev</build_depend>
+  <build_depend>gazebo_msgs</build_depend>
+  <build_depend>rclcpp</build_depend>
+
+  <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>gazebo_dev</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/mara_contact_publisher/src/ContactPublisher.cpp
+++ b/mara_contact_publisher/src/ContactPublisher.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gazebo/transport/transport.hh>
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/gazebo_client.hh>
+
+#include <gazebo_msgs/msg/contact_state.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
+
+#include <gazebo_ros/node.hpp>
+#include <gazebo/transport/Node.hh>
+
+#include <gazebo/gazebo_client.hh>
+
+#include <iostream>
+
+gazebo_ros::Node::SharedPtr ros_node;
+
+rclcpp::Publisher<gazebo_msgs::msg::ContactState>::SharedPtr contacts_pub ;
+
+gazebo::transport::NodePtr gz_node;
+
+// Function is called everytime a message is received.
+void cb(ConstContactsPtr &_msg)
+{
+  gazebo_msgs::msg::ContactState contact;
+  geometry_msgs::msg::Vector3 position;
+  geometry_msgs::msg::Vector3 normals;
+
+
+  if (_msg->contact_size() > 0){
+    if (_msg->contact(0).collision1() != "ground_plane::link::collision" && _msg->contact(0).collision2() != "ground_plane::link::collision"){
+      contact.collision1_name = _msg->contact(0).collision1();
+      contact.collision2_name = _msg->contact(0).collision2();
+
+      for (int j = 0; j <  _msg->contact(0).position_size(); ++j){
+        contact.collision1_name = _msg->contact(0).collision1();
+        contact.collision2_name = _msg->contact(0).collision2();
+
+        position.x =  _msg->contact(0).position(j).x();
+        position.y =  _msg->contact(0).position(j).y();
+        position.z =  _msg->contact(0).position(j).z();
+        contact.contact_positions.push_back(position);
+
+        normals.x =  _msg->contact(0).normal(j).x();
+        normals.y =  _msg->contact(0).normal(j).y();
+        normals.z =  _msg->contact(0).normal(j).z();
+        contact.contact_normals.push_back(normals);
+
+        contact.depths.push_back(static_cast<float>(_msg->contact(0).depth(0)));
+      }
+    }
+  }
+  contacts_pub->publish(contact);
+
+}
+
+/////////////////////////////////////////////////
+int main(int argc, char ** argv)
+{
+  // Load gazebo
+  gazebo::client::setup(argc, argv);
+
+  if (!rclcpp::is_initialized()) {
+    rclcpp::init(argc, argv);
+    ros_node = gazebo_ros::Node::Get();
+  } else {
+    ros_node = gazebo_ros::Node::Get();
+  }
+
+  contacts_pub = ros_node->create_publisher<gazebo_msgs::msg::ContactState>("/gazebo_contacts");
+
+  // Gazebo transport
+  gz_node = gazebo::transport::NodePtr(new gazebo::transport::Node());
+  gz_node->Init();
+
+  // Listen to Gazebo world_stats topic
+  gazebo::transport::SubscriberPtr sub = gz_node->Subscribe("~/physics/contacts", cb);
+
+  // Busy wait loop...replace with your own code as needed.
+  while (true)
+    gazebo::common::Time::MSleep(10);
+
+  // Make sure to shut everything down.
+  gazebo::client::shutdown();
+}


### PR DESCRIPTION
Migrate `mara_contact_plugin` (which is not a plugin) to `mara_contact_publisher`. Needed to detect collisions in gym-gazebo.

This is a ros node so it should not live under `gazebo_ros_pkgs`, but its not MARA specific neither. Anyway, I believe this repo is the best place to locate the publisher for now.