### PR TITLE
Fixing callback and result for dashing

### DIFF
--- a/individual_trajectories_bridge/src/FollowJointTrajectoryAction.cpp
+++ b/individual_trajectories_bridge/src/FollowJointTrajectoryAction.cpp
@@ -92,11 +92,22 @@ void FollowJointTrajectoryAction::executeCB(const control_msgs::FollowJointTraje
 
 
   printf("Sending goal\n");
-  std::function<void( rclcpp_action::ClientGoalHandle<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory>::SharedPtr,
-                      const std::shared_ptr<const hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory::Feedback> feedback )> cb_function = std::bind(
-        &FollowJointTrajectoryAction::feedback_callback, this, std::placeholders::_1,  std::placeholders::_2);
+  // std::function<void( rclcpp_action::ClientGoalHandle<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory>::SharedPtr,
+  //                     const std::shared_ptr<const hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory::Feedback> feedback )> cb_function = std::bind(
+  //       &FollowJointTrajectoryAction::feedback_callback, this, std::placeholders::_1,  std::placeholders::_2);
+  bool goal_response_received = false;
+  auto send_goal_ops = rclcpp_action::Client<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory>::SendGoalOptions();
+  send_goal_ops.goal_response_callback =
+    [&goal_response_received]
+      (std::shared_future<typename rclcpp_action::ClientGoalHandle<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory>::SharedPtr> future) mutable
+    {
+      auto goal_handle = future.get();
+      if (goal_handle) {
+        goal_response_received = true;
+      }
+    };
 
-  auto goal_handle_future = action_client->async_send_goal(goal_msg, cb_function);
+  auto goal_handle_future = action_client->async_send_goal(goal_msg, send_goal_ops);
 
   if (goal_handle_future.wait_for(std::chrono::seconds(5s)) != std::future_status::ready)
   {
@@ -120,7 +131,7 @@ void FollowJointTrajectoryAction::executeCB(const control_msgs::FollowJointTraje
     return;
   }
 
-  rclcpp_action::ClientGoalHandle<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory>::Result result = result_future.get();
+  rclcpp_action::ClientGoalHandle<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory>::WrappedResult result = result_future.get();
 
   switch(result.code) {
     case rclcpp_action::ResultCode::SUCCEEDED:


### PR DESCRIPTION
The following error apears when compiling  with dashing

```bash

erle@kaladin:~/myfiles/github/moveitmaster$ colcon build --merge-install --packages-select individual_trajectories_bridge
Starting >>> individual_trajectories_bridge
--- stderr: individual_trajectories_bridge                             
/mnt/myfiles/github/moveitmaster/src/mara/individual_trajectories_bridge/src/FollowJointTrajectoryAction.cpp: In member function ‘void FollowJointTrajectoryAction::executeCB(const FollowJointTrajectoryGoalConstPtr&)’:
/mnt/myfiles/github/moveitmaster/src/mara/individual_trajectories_bridge/src/FollowJointTrajectoryAction.cpp:99:81: error: no matching function for call to ‘rclcpp_action::Client<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory>::async_send_goal(hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory_Goal_<std::allocator<void> >&, std::function<void(std::shared_ptr<rclcpp_action::ClientGoalHandle<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory> >, std::shared_ptr<const hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory_Feedback_<std::allocator<void> > >)>&)’
   auto goal_handle_future = action_client->async_send_goal(goal_msg, cb_function);
                                                                                 ^
In file included from /opt/ros/dashing/include/rclcpp_action/rclcpp_action.hpp:36:0,
                 from /mnt/myfiles/github/moveitmaster/src/mara/individual_trajectories_bridge/include/FollowJointTrajectoryAction.hpp:32,
                 from /mnt/myfiles/github/moveitmaster/src/mara/individual_trajectories_bridge/src/FollowJointTrajectoryAction.cpp:1:
/opt/ros/dashing/include/rclcpp_action/client.hpp:343:3: note: candidate: std::shared_future<typename rclcpp_action::ClientGoalHandle<ActionT>::SharedPtr> rclcpp_action::Client<ActionT>::async_send_goal(const Goal&, const rclcpp_action::Client<ActionT>::SendGoalOptions&) [with ActionT = hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory; typename rclcpp_action::ClientGoalHandle<ActionT>::SharedPtr = std::shared_ptr<rclcpp_action::ClientGoalHandle<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory> >; rclcpp_action::Client<ActionT>::Goal = hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory_Goal_<std::allocator<void> >]
   async_send_goal(const Goal & goal, const SendGoalOptions & options = SendGoalOptions())
   ^~~~~~~~~~~~~~~
/opt/ros/dashing/include/rclcpp_action/client.hpp:343:3: note:   no known conversion for argument 2 from ‘std::function<void(std::shared_ptr<rclcpp_action::ClientGoalHandle<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory> >, std::shared_ptr<const hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory_Feedback_<std::allocator<void> > >)>’ to ‘const rclcpp_action::Client<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory>::SendGoalOptions&’
/mnt/myfiles/github/moveitmaster/src/mara/individual_trajectories_bridge/src/FollowJointTrajectoryAction.cpp:123:133: error: conversion from ‘const rclcpp_action::ClientGoalHandle<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory>::WrappedResult’ to non-scalar type ‘rclcpp_action::ClientGoalHandle<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory>::Result {aka hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory_Result_<std::allocator<void> >}’ requested
   rclcpp_action::ClientGoalHandle<hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory>::Result result = result_future.get();
                                                                                                                    ~~~~~~~~~~~~~~~~~^~
/mnt/myfiles/github/moveitmaster/src/mara/individual_trajectories_bridge/src/FollowJointTrajectoryAction.cpp:125:17: error: ‘using Result = using Result = using GoalJointTrajectory_Result = struct hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory_Result_<std::allocator<void> > {aka struct hrim_actuator_rotaryservo_actions::action::GoalJointTrajectory_Result_<std::allocator<void> >}’ has no member named ‘code’
   switch(result.code) {
                 ^~~~
/mnt/myfiles/github/moveitmaster/src/mara/individual_trajectories_bridge/src/FollowJointTrajectoryAction.cpp:126:37: error: could not convert ‘SUCCEEDED’ from ‘rclcpp_action::ResultCode’ to ‘<type error>’
     case rclcpp_action::ResultCode::SUCCEEDED:
                                     ^~~~~~~~~
/mnt/myfiles/github/moveitmaster/src/mara/individual_trajectories_bridge/src/FollowJointTrajectoryAction.cpp:128:37: error: could not convert ‘ABORTED’ from ‘rclcpp_action::ResultCode’ to ‘<type error>’
     case rclcpp_action::ResultCode::ABORTED:
                                     ^~~~~~~
/mnt/myfiles/github/moveitmaster/src/mara/individual_trajectories_bridge/src/FollowJointTrajectoryAction.cpp:131:37: error: could not convert ‘CANCELED’ from ‘rclcpp_action::ResultCode’ to ‘<type error>’
     case rclcpp_action::ResultCode::CANCELED:
                                     ^~~~~~~~
make[2]: *** [CMakeFiles/individual_trajectories_bridge_actions.dir/src/FollowJointTrajectoryAction.cpp.o] Error 1
make[1]: *** [CMakeFiles/individual_trajectories_bridge_actions.dir/all] Error 2
make: *** [all] Error 2
---
Failed   <<< individual_trajectories_bridge	[ Exited with code 2 ]

Summary: 0 packages finished [4.42s]
  1 package failed: individual_trajectories_bridge
  1 package had stderr output: individual_trajectories_bridge

```