### PR TITLE
Updated QoS & deleted intra_process_comms (No LC node))

### DIFF
--- a/hros_cognition_mara_components/include/HROSCognitionMaraComponents.hpp
+++ b/hros_cognition_mara_components/include/HROSCognitionMaraComponents.hpp
@@ -27,7 +27,7 @@ class HROSCognitionMaraComponentsNode : public rclcpp::Node
      * arguments a regular node.
      */
     explicit HROSCognitionMaraComponentsNode(const std::string & node_name,
-                        int argc, char **argv, bool intra_process_comms = false);
+                        int argc, char **argv);
 
     /// Callback for walltimer in order to publish the message.
     /**


### PR DESCRIPTION
### Dashing migration (avoiding warnings):
- Updated QoS policies -> Publishers & Subscribers (changes parameter order)
- Deleted intra_process_comms variable as it is not a LifeCycle Node